### PR TITLE
bug fix to alias p1000mb to P0

### DIFF
--- a/MPAS/module_ruc_ice.F90
+++ b/MPAS/module_ruc_ice.F90
@@ -8,7 +8,7 @@
 module module_ruc_ice
 
 #if defined(mpas)
-use mpas_atmphys_constants, g => gravity,rhowater=>rho_w, piconst => pii
+use mpas_atmphys_constants, g => gravity,rhowater=>rho_w, piconst => pii, p1000mb => P0
 use mpas_atmphys_utilities, only: physics_error_fatal,physics_message
 use mpas_log, only: mpas_log_write
 #define em_core 1

--- a/MPAS/module_ruc_land.F90
+++ b/MPAS/module_ruc_land.F90
@@ -19,7 +19,7 @@ module module_ruc_land
 ! to reflect their dimension rstochcol (1:nzs)
 
 #if defined(mpas)
-use mpas_atmphys_constants, g => gravity,rhowater=>rho_w, piconst => pii
+use mpas_atmphys_constants, g => gravity,rhowater=>rho_w, piconst => pii, p1000mb => P0
 use mpas_atmphys_utilities, only: physics_error_fatal,physics_message
 use mpas_log, only: mpas_log_write
 #define em_core 1


### PR DESCRIPTION
I found that p1000mb was not set to anything inside the modules for land and ice in the MPAS version of the RUCLSM.  So compile fails with GNU 12.3 and with Intel.